### PR TITLE
Reduce code size on latest Rust

### DIFF
--- a/hqx/src/common.rs
+++ b/hqx/src/common.rs
@@ -113,12 +113,11 @@ pub fn interp10(c1: u32, c2: u32, c3: u32) -> u32 {
 // A wrapper that allows any indexing panics to point to the same location,
 // significantly reducing size of the generated code.
 #[repr(transparent)]
-pub struct Dst([u32]);
+pub struct UncheckedDst([u32]);
 
-impl Dst {
-    pub fn from_mut(dst: &mut [u32]) -> &mut Self {
-        // This is safe because it's `#[repr(transparent)]`.
-        unsafe { &mut *(dst as *mut [u32] as *mut Self) }
+impl UncheckedDst {
+    pub unsafe fn from_mut(dst: &mut [u32]) -> &mut Self {
+        &mut *(dst as *mut [u32] as *mut Self)
     }
 }
 
@@ -133,7 +132,7 @@ fn unwrap_index<T>(option: Option<T>) -> T {
     }
 }
 
-impl std::ops::Index<usize> for Dst {
+impl std::ops::Index<usize> for UncheckedDst {
     type Output = u32;
 
     #[inline(always)]
@@ -142,7 +141,7 @@ impl std::ops::Index<usize> for Dst {
     }
 }
 
-impl std::ops::IndexMut<usize> for Dst {
+impl std::ops::IndexMut<usize> for UncheckedDst {
     #[inline(always)]
     fn index_mut(&mut self, index: usize) -> &mut u32 {
         unwrap_index(self.0.get_mut(index))

--- a/hqx/src/hq2x.rs
+++ b/hqx/src/hq2x.rs
@@ -1,4 +1,4 @@
-use common::{diff, rgb_to_yuv, yuv_diff, interp1, interp10, interp2, interp6, interp7, interp9};
+use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp10, interp2, interp6, interp7, interp9};
 
 macro_rules! pixel00_0 {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -254,6 +254,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
+    let dst = Dst::from_mut(dst);
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;

--- a/hqx/src/hq2x.rs
+++ b/hqx/src/hq2x.rs
@@ -1,4 +1,4 @@
-use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp10, interp2, interp6, interp7, interp9};
+use common::{UncheckedDst, diff, rgb_to_yuv, yuv_diff, interp1, interp10, interp2, interp6, interp7, interp9};
 
 macro_rules! pixel00_0 {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -254,7 +254,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
-    let dst = Dst::from_mut(dst);
+    let dst = unsafe { UncheckedDst::from_mut(dst) };
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;

--- a/hqx/src/hq3x.rs
+++ b/hqx/src/hq3x.rs
@@ -1,4 +1,4 @@
-use common::{diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp4, interp5};
+use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp4, interp5};
 
 macro_rules! pixel00_1_m {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -247,6 +247,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
+    let dst = Dst::from_mut(dst);
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;

--- a/hqx/src/hq3x.rs
+++ b/hqx/src/hq3x.rs
@@ -1,4 +1,4 @@
-use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp4, interp5};
+use common::{UncheckedDst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp4, interp5};
 
 macro_rules! pixel00_1_m {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -247,7 +247,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
-    let dst = Dst::from_mut(dst);
+    let dst = unsafe { UncheckedDst::from_mut(dst) };
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;

--- a/hqx/src/hq4x.rs
+++ b/hqx/src/hq4x.rs
@@ -1,4 +1,4 @@
-use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp5, interp6, interp7, interp8};
+use common::{UncheckedDst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp5, interp6, interp7, interp8};
 
 macro_rules! pixel00_0 {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -714,7 +714,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
-    let dst = Dst::from_mut(dst);
+    let dst = unsafe { UncheckedDst::from_mut(dst) };
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;

--- a/hqx/src/hq4x.rs
+++ b/hqx/src/hq4x.rs
@@ -1,4 +1,4 @@
-use common::{diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp5, interp6, interp7, interp8};
+use common::{Dst, diff, rgb_to_yuv, yuv_diff, interp1, interp2, interp3, interp5, interp6, interp7, interp8};
 
 macro_rules! pixel00_0 {
     ($dst:ident, $dst_index:ident, $dst_row_elements:ident, $w:ident) => {
@@ -714,6 +714,7 @@ pub fn inner(
     width: usize,
     height: usize,
 ) {
+    let dst = Dst::from_mut(dst);
     let mut w = [0; 10];
     let src_row_elements = (src_row_bytes >> 2) as isize;
     let dst_row_elements = (dst_row_bytes >> 2) as isize;


### PR DESCRIPTION
A simple workaround for https://github.com/rust-lang/rust/issues/74947 which made each indexing location include itself as a string in the final binary, resulting in a significant code bloat in case of hqx which generates a lot of indexing via macros.

Stats for a simple Wasm that reexports all 3 variants of HQX:

initial size:                         462,076 bytes
Dst wrapper with unreachable!:        250,225 bytes
Dst wrapper with debug_unreachable!:  190,312 bytes

I'm open to removing `debug_unreachable!` in favour of just `unreachable`, but I was assuming that indexing code is well-tested and the extra difference seemed nice to have.